### PR TITLE
ignore blacklisting "module" and "es2015" entries when they specify individual files

### DIFF
--- a/functions/api/__snapshots__/merge-results.test.ts.snap
+++ b/functions/api/__snapshots__/merge-results.test.ts.snap
@@ -488,8 +488,8 @@ Object {
 exports[`mergeResults can merge web3 1`] = `
 Object {
   "contents": Object {
-    "/node_modules/web3-provider-engine/13.8.0/package.json": Object {
-      "contents": "{}",
+    "/node_modules/web3-provider-engine/package.json": Object {
+      "contents": "{ \\"title\\": \\"test\\" }",
     },
     "/node_modules/web3/package.json": Object {
       "contents": "{}",
@@ -505,11 +505,7 @@ Object {
       "version": "14.0.5",
     },
   ],
-  "dependencyAliases": Object {
-    "eth-tx-summary": Object {
-      "web3-provider-engine": "web3-provider-engine/13.8.0",
-    },
-  },
+  "dependencyAliases": Object {},
   "dependencyDependencies": Object {
     "abstract-leveldown": Object {
       "entries": Array [
@@ -580,7 +576,7 @@ Object {
         "async/waterfall",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "json-rpc-engine",
         "eth-json-rpc-middleware",
         "eth-tx-summary",
@@ -1179,7 +1175,7 @@ Object {
         "backoff",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "2.5.0",
       "semver": "^2.5.0",
@@ -1369,7 +1365,7 @@ Object {
         "clone",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "json-rpc-engine",
         "eth-tx-summary",
       ],
@@ -1472,7 +1468,7 @@ Object {
         "cross-fetch",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-infura",
       ],
       "resolved": "2.2.0",
@@ -1670,7 +1666,7 @@ Object {
         "eth-block-tracker",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "3.0.1",
       "semver": "^3.0.0",
@@ -1680,7 +1676,7 @@ Object {
         "eth-json-rpc-infura/src/createProvider",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "3.1.2",
       "semver": "^3.1.0",
@@ -1713,7 +1709,7 @@ Object {
       ],
       "parents": Array [
         "eth-json-rpc-middleware",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "1.4.2",
       "semver": "^1.4.2",
@@ -1766,7 +1762,7 @@ Object {
       "parents": Array [
         "eth-tx-summary",
         "ethereumjs-vm",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "1.7.1",
@@ -1781,7 +1777,7 @@ Object {
         "eth-block-tracker",
         "ethereumjs-block",
         "eth-tx-summary",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "1.3.4",
@@ -1801,7 +1797,7 @@ Object {
         "eth-tx-summary",
         "ethereumjs-account",
         "ethereumjs-vm",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "5.2.0",
@@ -1813,7 +1809,7 @@ Object {
       ],
       "parents": Array [
         "eth-tx-summary",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "2.3.5",
@@ -1884,7 +1880,7 @@ Object {
     "fetch-ponyfill": Object {
       "entries": Array [],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "4.1.0",
@@ -2363,7 +2359,7 @@ Object {
       ],
       "parents": Array [
         "json-rpc-engine",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
         "eth-json-rpc-infura",
       ],
@@ -2401,7 +2397,7 @@ Object {
         "json-stable-stringify",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "1.0.1",
@@ -2948,7 +2944,7 @@ Object {
       ],
       "parents": Array [
         "json-rpc-engine",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
       ],
       "resolved": "1.0.0",
@@ -3012,7 +3008,7 @@ Object {
         "level-iterator-stream",
         "merkle-patricia-tree",
         "through2",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "2.3.6",
       "semver": "^2.2.2",
@@ -3078,7 +3074,7 @@ Object {
         "request",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "2.86.0",
       "semver": "^2.67.0",
@@ -3208,7 +3204,7 @@ Object {
       ],
       "parents": Array [
         "merkle-patricia-tree",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "1.1.0",
       "semver": ">=1.0.1",
@@ -3274,7 +3270,7 @@ Object {
         "solc",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "0.4.24",
       "semver": "^0.4.2",
@@ -3409,7 +3405,7 @@ Object {
       "entries": Array [],
       "parents": Array [
         "eth-block-tracker",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
         "eth-json-rpc-middleware",
         "eth-json-rpc-infura",
       ],
@@ -3535,7 +3531,7 @@ Object {
       "resolved": "1.10.0",
       "semver": "1.10.0",
     },
-    "web3-provider-engine/13.8.0": Object {
+    "web3-provider-engine": Object {
       "entries": Array [],
       "parents": Array [
         "eth-tx-summary",
@@ -3589,7 +3585,7 @@ Object {
         "ws",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "5.1.1",
       "semver": "^5.1.1",
@@ -3599,7 +3595,7 @@ Object {
         "xhr",
       ],
       "parents": Array [
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "2.4.1",
       "semver": "^2.2.0",
@@ -3636,7 +3632,7 @@ Object {
         "levelup",
         "through2",
         "xhr",
-        "web3-provider-engine/13.8.0",
+        "web3-provider-engine",
       ],
       "resolved": "4.0.1",
       "semver": "^4.0.1",

--- a/functions/api/merge-results.test.ts
+++ b/functions/api/merge-results.test.ts
@@ -385,11 +385,16 @@ describe("mergeResults", () => {
   });
 
   it.only("can merge web3", async () => {
+    const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
     const web3 = await downloadFixture("web3", "0.20.6");
     const web3ProviderEngine = await downloadFixture(
       "web3-provider-engine",
       "14.0.5",
     );
+
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
 
     web3.contents = {
       "/node_modules/web3/package.json": {

--- a/functions/packager/packages/resolve-required-files.ts
+++ b/functions/packager/packages/resolve-required-files.ts
@@ -88,13 +88,13 @@ function isValidFile(packagePath: string, packageInfo: IPackage) {
 
   // We only want to include the index.js and not those subdirs. An example of this
   // is rxjs.
-  if (packageInfo.module) {
+  if (typeof packageInfo.module === "string") {
     moduleDir = dirname(join(packagePath, packageInfo.module))
       .replace(packagePath, "")
       .slice(1);
   }
 
-  if (packageInfo.es2015) {
+  if (typeof packageInfo.es2015 === "string") {
     es2015Dir = dirname(join(packagePath, packageInfo.es2015))
       .replace(packagePath, "")
       .slice(1);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-config-prettier": "^2.6.0",
     "express": "^4.16.1",
     "jest": "^21.2.1",
+    "node-fetch": "^2.2.0",
     "serverless-api-cloudfront": "^0.9.2",
     "serverless-offline": "^3.16.0",
     "serverless-plugin-typescript": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,6 +2770,10 @@ node-fetch-npm@^2.0.1:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://unpm.uberinternal.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
For example, if we have

```json

  "browser": {
    "./dist/index.js": "./dist/browser.es5.js",
    "./dist/index.es.js": "./dist/browser.es5.es.js"
  },

```

Like https://github.com/fusionjs/fusion-tokens/blob/master/package.json#L11

codesandbox will thrown an error:

```
Error: Could not fetch dependencies, please try again in a couple seconds: Something went wrong while packaging the dependency fusion-react@1.1.0: Path must be a string. Received { './dist/browser.es5.es.js': './dist/browser.es2015.es.js' }
```

![codesandbox-pack](https://user-images.githubusercontent.com/1486609/43555062-e3f3e7f0-95ac-11e8-9bbb-e81333004c7a.gif)


Maybe we should blacklist these individual files, but I think this is OK for a short term fix