### PR TITLE
Reason downloader: remove unneeded map()

### DIFF
--- a/functions/packager/packages/reason-downloader.ts
+++ b/functions/packager/packages/reason-downloader.ts
@@ -62,7 +62,6 @@ export async function getReasonFiles(
               // Read all subdirs
               return recursiveReaddir(packagePath).then(f =>
                 f
-                  .map(file => join(packagePath, file))
                   .filter(p => fs.lstatSync(p).isDirectory()),
               );
             }


### PR DESCRIPTION
Remove unneeded `map()`, as `recursiveReaddir()` already returns the full path.

Might fix https://github.com/codesandbox/codesandbox-client/issues/3371 .